### PR TITLE
PR for issue 28

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 ===========
 
+v. 2.2.0
+--------
+
+    * Add new classes ``ColumnShiftTableBootstrap4Responsive`` and ``ColumnShiftTableBootstrap5Responsive``
+      to be able to use responsive tables with Bootstrap v4 and v5 (@mpibpc-mroose)
+
 v. 2.1.1
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 CHANGELOG
 ===========
 
+v. 2.2.0
+--------
+
+    * Add new classes:
+        * ``ColumnShiftTableBootstrap4Responsive`` - only for django-tables2 >= 2.5.0
+        * ``ColumnShiftTableBootstrap5Responsive`` - only for django-tables2 >= 2.5.3
+
+      Classes able to use responsive tables with Bootstrap v4 and v5
+      Author: @mpibpc-mroose
+
 v. 2.1.1
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Using JQuery, Bootstrap3 or Bootstrap4 or Bootstrap5 and Django >=1.9.
 
   * for bootstrap2 - ColumnShiftTableBootstrap2,
   * for bootstrap3 - ColumnShiftTableBootstrap3,
-  * for bootstrap4 - ColumnShiftTableBootstrap4,
-  * for bootstrap5 - ColumnShiftTableBootstrap5,
+  * for bootstrap4 - ColumnShiftTableBootstrap4 or ColumnShiftTableBootstrap4Responsive,
+  * for bootstrap5 - ColumnShiftTableBootstrap5 or ColumnShiftTableBootstrap5Responsive.
 
 **Tested by tox with:**
 
@@ -218,11 +218,16 @@ Bootstrap4 :
 If you use Bootstrap v4 in your project then table class has to inherit from `ColumnShiftTableBootstrap4`
 imported from `django_tables2_column_shifter.tables`.
 
+Alternatively if you want to use `table-responsive` your table class has to inherit from
+`ColumnShiftTableBootstrap4Responsive` imported from `django_tables2_column_shifter.tables`.
+
 Bootstrap5:
 --------------------------------------
 If you use Bootstrap v5 in your project then table class has to inherit from `ColumnShiftTableBootstrap5`
 imported from `django_tables2_column_shifter.tables`.
 
+Alternatively if you want to use `table-responsive` your table class has to inherit from
+`ColumnShiftTableBootstrap5Responsive` imported from `django_tables2_column_shifter.tables`.
 
 
 Warnings:

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,10 @@ Using JQuery, Bootstrap3 or Bootstrap4 or Bootstrap5 and Django >=1.9.
 
   * for bootstrap2 - ColumnShiftTableBootstrap2,
   * for bootstrap3 - ColumnShiftTableBootstrap3,
-  * for bootstrap4 - ColumnShiftTableBootstrap4,
-  * for bootstrap5 - ColumnShiftTableBootstrap5,
+  * for bootstrap4 - ColumnShiftTableBootstrap4
+  * for bootstrap4 in responsive mode - ColumnShiftTableBootstrap4Responsive (only for django-tables2 >= 2.5)
+  * for bootstrap5 - ColumnShiftTableBootstrap5
+  * for bootstrap5 in responsive mode - ColumnShiftTableBootstrap5Responsive (only for django-tables2 >= 2.5.3)
 
 **Tested by tox with:**
 
@@ -218,11 +220,16 @@ Bootstrap4 :
 If you use Bootstrap v4 in your project then table class has to inherit from `ColumnShiftTableBootstrap4`
 imported from `django_tables2_column_shifter.tables`.
 
+Alternatively if you want to use `table-responsive` your table class has to inherit from
+ColumnShiftTableBootstrap4Responsive (only for django-tables2 >= 2.5).
+
 Bootstrap5:
 --------------------------------------
 If you use Bootstrap v5 in your project then table class has to inherit from `ColumnShiftTableBootstrap5`
 imported from `django_tables2_column_shifter.tables`.
 
+Alternatively if you want to use `table-responsive` your table class has to inherit from
+ColumnShiftTableBootstrap5Responsive (only for django-tables2 >= 2.5.3).
 
 
 Warnings:

--- a/django_tables2_column_shifter/__init__.py
+++ b/django_tables2_column_shifter/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (2, 1, 1)
+VERSION = (2, 2, 0)
 __version__ = ".".join(str(i) for i in VERSION)

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -95,6 +95,15 @@ class ColumnShiftTableBootstrap4Responsive(ColumnShiftTable):
     Table class compatible with Bootstrap 4 and using "table-responsive" css class.
     """
     shifter_template = "django_tables2_column_shifter/bootstrap4-responsive.html"
+    
+    def __init__(self, *args, **kwargs):
+        if dt_version < (2, 5):
+            raise AssertionError(
+                "ColumnShiftTableBootstrap4Responsive require django-tables2 >= 2.5 "
+                "your current version is {}".format(tables.__version__)
+            )
+        super(ColumnShiftTableBootstrap4Responsive, self).__init__(*args, **kwargs)
+
 
 
 class ColumnShiftTableBootstrap5(ColumnShiftTable):

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -126,3 +126,12 @@ class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
     Table class compatible with Bootstrap 5 and using "table-responsive" css class.
     """
     shifter_template = "django_tables2_column_shifter/bootstrap5-responsive.html"
+    
+    def __init__(self, *args, **kwargs):
+        if dt_version < (2, 5, 3):
+            raise AssertionError(
+                "ColumnShiftTableBootstrap5Responsive require django-tables2 >= 2.5.3 "
+                "your current version is {}".format(tables.__version__)
+            )
+        super(ColumnShiftTableBootstrap5Responsive, self).__init__(*args, **kwargs)
+

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -2,7 +2,6 @@ import django_tables2 as tables
 
 
 class ColumnShiftTable(tables.Table):
-
     # If button for shifting columns is visible
     shift_table_column = True
 
@@ -89,9 +88,23 @@ class ColumnShiftTableBootstrap4(ColumnShiftTable):
     shifter_template = "django_tables2_column_shifter/bootstrap4.html"
 
 
+class ColumnShiftTableBootstrap4Responsive(ColumnShiftTable):
+    """
+    Table class compatible with Bootstrap 4 and using "table-responsive" css class.
+    """
+    shifter_template = "django_tables2_column_shifter/bootstrap4-responsive.html"
+
+
 class ColumnShiftTableBootstrap5(ColumnShiftTable):
     """
     Table class compatible with bootstrap 5
     """
     dropdown_button_css = "btn btn-light btn-sm"
     shifter_template = "django_tables2_column_shifter/bootstrap5.html"
+
+
+class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
+    """
+    Table class compatible with Bootstrap 5 and using "table-responsive" css class.
+    """
+    shifter_template = "django_tables2_column_shifter/bootstrap5-responsive.html"

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -105,7 +105,6 @@ class ColumnShiftTableBootstrap4Responsive(ColumnShiftTable):
         super(ColumnShiftTableBootstrap4Responsive, self).__init__(*args, **kwargs)
 
 
-
 class ColumnShiftTableBootstrap5(ColumnShiftTable):
     """
     Table class compatible with bootstrap 5
@@ -121,6 +120,7 @@ class ColumnShiftTableBootstrap5(ColumnShiftTable):
             )
         super(ColumnShiftTableBootstrap5, self).__init__(*args, **kwargs)
 
+
 class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
     """
     Table class compatible with Bootstrap 5 and using "table-responsive" css class.
@@ -134,4 +134,3 @@ class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
                 "your current version is {}".format(tables.__version__)
             )
         super(ColumnShiftTableBootstrap5Responsive, self).__init__(*args, **kwargs)
-

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -113,6 +113,13 @@ class ColumnShiftTableBootstrap5(ColumnShiftTable):
     dropdown_button_css = "btn btn-light btn-sm"
     shifter_template = "django_tables2_column_shifter/bootstrap5.html"
 
+    def __init__(self, *args, **kwargs):
+        if dt_version < (2, 5):
+            raise AssertionError(
+                "ColumnShiftTableBootstrap5 require django-tables2 >= 2.5 "
+                "your current version is {}".format(tables.__version__)
+            )
+        super(ColumnShiftTableBootstrap5, self).__init__(*args, **kwargs)
 
 class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
     """

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -2,7 +2,6 @@ import django_tables2 as tables
 
 
 class ColumnShiftTable(tables.Table):
-
     # If button for shifting columns is visible
     shift_table_column = True
 
@@ -84,14 +83,28 @@ class ColumnShiftTableBootstrap3(ColumnShiftTable):
 
 class ColumnShiftTableBootstrap4(ColumnShiftTable):
     """
-    Table class compatible with bootstrap 4
+    Table class compatible with Bootstrap 4.
     """
     shifter_template = "django_tables2_column_shifter/bootstrap4.html"
 
 
+class ColumnShiftTableBootstrap4Responsive(ColumnShiftTable):
+    """
+    Table class compatible with Bootstrap 4 and using "table-responsive" css class.
+    """
+    shifter_template = "django_tables2_column_shifter/bootstrap4-responsive.html"
+
+
 class ColumnShiftTableBootstrap5(ColumnShiftTable):
     """
-    Table class compatible with bootstrap 5
+    Table class compatible with Bootstrap 5
     """
     dropdown_button_css = "btn btn-light btn-sm"
     shifter_template = "django_tables2_column_shifter/bootstrap5.html"
+
+
+class ColumnShiftTableBootstrap5Responsive(ColumnShiftTableBootstrap5):
+    """
+    Table class compatible with Bootstrap 5 and using "table-responsive" css class.
+    """
+    shifter_template = "django_tables2_column_shifter/bootstrap5-responsive.html"

--- a/django_tables2_column_shifter/tables.py
+++ b/django_tables2_column_shifter/tables.py
@@ -1,5 +1,7 @@
 import django_tables2 as tables
 
+dt_version = tuple(map(int, tables.__version__.split(".")[:3]))
+
 
 class ColumnShiftTable(tables.Table):
     # If button for shifting columns is visible

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -1,0 +1,80 @@
+{% load trans from i18n %}
+{% load static %}
+
+
+
+
+
+            <div class="btn-group">
+                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                >
+                    <img
+                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
+                        alt="Columns"
+                        style="
+                            width:20px;
+                            height:16px;
+                            margin-right:5px;
+                            opacity:0.7;"
+                    />
+                    {% trans "Visible columns" %}
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" style="min-width:350px; padding:5px; cursor:pointer;">
+                    {% for column in table.columns %}
+                        {% if column.attrs.td.class not in table.get_column_excluded %}
+                            {% if column.attrs.td.class in table.get_column_default_show %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="on"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% else %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="off"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div> {# End  btn-group#}
+
+            {# Loader default is show #}
+            <div class="loader" style="text-align:center;" >
+                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
+                {% trans "Table content is loading..."%}
+            </div> {# End loader #}
+

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -4,7 +4,6 @@
 
 
 
-
             <div class="btn-group">
                 <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
                         data-toggle="dropdown"

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -2,7 +2,6 @@
 {% load static %}
 
 
-
             <div class="btn-group">
                 <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
                         data-toggle="dropdown"

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -3,7 +3,7 @@
 
 
 
-        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+
 
             <div class="btn-group">
                 <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
@@ -78,10 +78,3 @@
                 {% trans "Table content is loading..."%}
             </div> {# End loader #}
 
-            {# Wrapper degault is hide #}
-            <div class="table-wrapper" style="display:none;">
-                {# Load default table content   #}
-                {{ block.super }}
-            </div> {# End table-wrapper #}
-
-        </div> {# End column-shifter-container #}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -3,7 +3,6 @@
 
 
 
-
             <div class="btn-group">
                 <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
                         data-toggle="dropdown"

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -1,7 +1,7 @@
 {% load trans from i18n %}
 {% load static %}
 
-    {% if table.shift_table_column %}
+
 
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
 
@@ -85,6 +85,3 @@
             </div> {# End table-wrapper #}
 
         </div> {# End column-shifter-container #}
-    {% else %}
-        {{ block.super }}
-    {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -1,0 +1,90 @@
+{% load trans from i18n %}
+{% load static %}
+
+    {% if table.shift_table_column %}
+
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+
+            <div class="btn-group">
+                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                >
+                    <img
+                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
+                        alt="Columns"
+                        style="
+                            width:20px;
+                            height:16px;
+                            margin-right:5px;
+                            opacity:0.7;"
+                    />
+                    {% trans "Visible columns" %}
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" style="min-width:350px; padding:5px; cursor:pointer;">
+                    {% for column in table.columns %}
+                        {% if column.attrs.td.class not in table.get_column_excluded %}
+                            {% if column.attrs.td.class in table.get_column_default_show %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="on"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% else %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="off"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div> {# End  btn-group#}
+
+            {# Loader default is show #}
+            <div class="loader" style="text-align:center;" >
+                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
+                {% trans "Table content is loading..."%}
+            </div> {# End loader #}
+
+            {# Wrapper degault is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+
+        </div> {# End column-shifter-container #}
+    {% else %}
+        {{ block.super }}
+    {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
@@ -1,0 +1,79 @@
+{% load trans from i18n %}
+{% load static %}
+
+            <div class="btn-group">
+                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
+                        data-bs-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="btn_{{ table.uniq_table_class_name }}"
+                >
+                    <img
+                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
+                        alt="Columns"
+                        style="
+                            width:20px;
+                            height:16px;
+                            margin-right:5px;
+                            opacity:0.7;"
+                    />
+                    {% trans "Visible columns" %}
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu"
+                    style="min-width:350px; padding:5px; cursor:pointer;"
+                    aria-labelledby="btn_{{ table.uniq_table_class_name }}"
+                >
+                    {% for column in table.columns %}
+                        {% if column.attrs.td.class not in table.get_column_excluded %}
+                            {% if column.attrs.td.class in table.get_column_default_show %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="on"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% else %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="off"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div> {# End  btn-group#}
+
+            {# Loader default is show #}
+            <div class="loader" style="text-align:center;" >
+                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
+                {% trans "Table content is loading..."%}
+            </div> {# End loader #}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
@@ -1,9 +1,6 @@
 {% load trans from i18n %}
 {% load static %}
 
-
-        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
-
             <div class="btn-group">
                 <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
                         data-bs-toggle="dropdown"
@@ -80,11 +77,3 @@
                 <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
                 {% trans "Table content is loading..."%}
             </div> {# End loader #}
-
-            {# Wrapper degault is hide #}
-            <div class="table-wrapper" style="display:none;">
-                {# Load default table content   #}
-                {{ block.super }}
-            </div> {# End table-wrapper #}
-
-        </div> {# End column-shifter-container #}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
@@ -1,0 +1,95 @@
+{% load trans from i18n %}
+{% load static %}
+
+
+    {% if table.shift_table_column %}
+
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+
+            <div class="btn-group">
+                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
+                        data-bs-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="btn_{{ table.uniq_table_class_name }}"
+                >
+                    <img
+                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
+                        alt="Columns"
+                        style="
+                            width:20px;
+                            height:16px;
+                            margin-right:5px;
+                            opacity:0.7;"
+                    />
+                    {% trans "Visible columns" %}
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu"
+                    style="min-width:350px; padding:5px; cursor:pointer;"
+                    aria-labelledby="btn_{{ table.uniq_table_class_name }}"
+                >
+                    {% for column in table.columns %}
+                        {% if column.attrs.td.class not in table.get_column_excluded %}
+                            {% if column.attrs.td.class in table.get_column_default_show %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="on"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% else %}
+                                <li class="btn-shift-column"
+                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-state="off"
+                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
+                                    data-table-class-container="{{ table.uniq_table_class_name }}">
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
+                                        class="ico check"
+                                    />
+                                    <img
+                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
+                                        alt="loader"
+                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
+                                        class="ico uncheck"
+                                    />
+                                    {{ column.header }}
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div> {# End  btn-group#}
+
+            {# Loader default is show #}
+            <div class="loader" style="text-align:center;" >
+                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
+                {% trans "Table content is loading..."%}
+            </div> {# End loader #}
+
+            {# Wrapper degault is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+
+        </div> {# End column-shifter-container #}
+    {% else %}
+        {{ block.super }}
+    {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
@@ -2,8 +2,6 @@
 {% load static %}
 
 
-    {% if table.shift_table_column %}
-
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
 
             <div class="btn-group">
@@ -90,6 +88,3 @@
             </div> {# End table-wrapper #}
 
         </div> {# End column-shifter-container #}
-    {% else %}
-        {{ block.super }}
-    {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,0 +1,17 @@
+{% extends "django_tables2/bootstrap4-responsive.html" %}
+
+{% block table %}
+{% if table.shift_table_column %}
+    <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+
+        {# Wrapper default is hide #}
+        <div class="table-wrapper" style="display:none;">
+            {# Load default table content   #}
+            {{ block.super }}
+        </div> {# End table-wrapper #}
+     </div> {# End column-shifter-container #}
+{% else %}
+    {{ block.super }}
+{% endif %}
+{% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,5 +1,9 @@
 {% extends "django_tables2/bootstrap4-responsive.html" %}
 
 {% block table %}
-    {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+    {% if table.shift_table_column %}
+        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
 {% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,6 +1,8 @@
 {% extends "django_tables2/bootstrap4-responsive.html" %}
 
-{% block table %}
+{% block table-wrapper %}
+<div class="table-container table-responsive">
+    {% block table %}
     {% if table.shift_table_column %}
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
             {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
@@ -14,4 +16,12 @@
     {% else %}
         {{ block.super }}
     {% endif %}
+
 {% endblock table %}
+{% block pagination %}
+    {% if table.page and table.paginator.num_pages > 1 %}
+    {{ block.super }}
+    {% endif %}
+    {% endblock pagination %}
+</div>
+{% endblock table-wrapper %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -2,7 +2,15 @@
 
 {% block table %}
     {% if table.shift_table_column %}
-        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+
+            {# Wrapper default is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,4 +1,4 @@
-{% extends "django_tables2/bootstrap4.html" %}
+{% extends "django_tables2/bootstrap4-responsive.html" %}
 
 {% block table %}
     {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,4 +1,4 @@
-{% extends "django_tables2/bootstrap4-responsive.html" %}
+{% extends "django_tables2/bootstrap4.html" %}
 
 {% block table-wrapper %}
 <div class="table-container table-responsive">
@@ -16,9 +16,9 @@
     {% else %}
         {{ block.super }}
     {% endif %}
+    {% endblock table %}
 
-{% endblock table %}
-{% block pagination %}
+    {% block pagination %}
     {% if table.page and table.paginator.num_pages > 1 %}
     {{ block.super }}
     {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -7,7 +7,7 @@
 
         {# Wrapper default is hide #}
         <div class="table-wrapper" style="display:none;">
-            {# Load default table content   #}
+            {# Load default table content #}
             {{ block.super }}
         </div> {# End table-wrapper #}
      </div> {# End column-shifter-container #}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,17 +1,17 @@
 {% extends "django_tables2/bootstrap4-responsive.html" %}
 
-    {% block table %}
-    {% if table.shift_table_column %}
-        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
-            {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+{% block table %}
+{% if table.shift_table_column %}
+    <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
 
-            {# Wrapper default is hide #}
-            <div class="table-wrapper" style="display:none;">
-                {# Load default table content   #}
-                {{ block.super }}
-            </div> {# End table-wrapper #}
-         </div> {# End column-shifter-container #}
-    {% else %}
-        {{ block.super }}
-    {% endif %}
-    {% endblock table %}
+        {# Wrapper default is hide #}
+        <div class="table-wrapper" style="display:none;">
+            {# Load default table content   #}
+            {{ block.super }}
+        </div> {# End table-wrapper #}
+     </div> {# End column-shifter-container #}
+{% else %}
+    {{ block.super }}
+{% endif %}
+{% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4-responsive.html
@@ -1,7 +1,5 @@
-{% extends "django_tables2/bootstrap4.html" %}
+{% extends "django_tables2/bootstrap4-responsive.html" %}
 
-{% block table-wrapper %}
-<div class="table-container table-responsive">
     {% block table %}
     {% if table.shift_table_column %}
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
@@ -17,11 +15,3 @@
         {{ block.super }}
     {% endif %}
     {% endblock table %}
-
-    {% block pagination %}
-    {% if table.page and table.paginator.num_pages > 1 %}
-    {{ block.super }}
-    {% endif %}
-    {% endblock pagination %}
-</div>
-{% endblock table-wrapper %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
@@ -1,95 +1,17 @@
 {% extends "django_tables2/bootstrap4.html" %}
-{% load trans from i18n %}
-{% load static %}
 
 {% block table %}
-
     {% if table.shift_table_column %}
-
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
 
-            <div class="btn-group">
-                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
-                        data-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                >
-                    <img
-                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
-                        alt="Columns"
-                        style="
-                            width:20px;
-                            height:16px;
-                            margin-right:5px;
-                            opacity:0.7;"
-                    />
-                    {% trans "Visible columns" %}
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" style="min-width:350px; padding:5px; cursor:pointer;">
-                    {% for column in table.columns %}
-                        {% if column.attrs.td.class not in table.get_column_excluded %}
-                            {% if column.attrs.td.class in table.get_column_default_show %}
-                                <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
-                                    data-state="on"
-                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
-                                    data-table-class-container="{{ table.uniq_table_class_name }}">
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
-                                        class="ico check"
-                                    />
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
-                                        class="ico uncheck"
-                                    />
-                                    {{ column.header }}
-                                </li>
-                            {% else %}
-                                <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
-                                    data-state="off"
-                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
-                                    data-table-class-container="{{ table.uniq_table_class_name }}">
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
-                                        class="ico check"
-                                    />
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
-                                        class="ico uncheck"
-                                    />
-                                    {{ column.header }}
-                                </li>
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div> {# End  btn-group#}
-
-            {# Loader default is show #}
-            <div class="loader" style="text-align:center;" >
-                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
-                {% trans "Table content is loading..."%}
-            </div> {# End loader #}
-
-            {# Wrapper degault is hide #}
+            {# Wrapper default is hide #}
             <div class="table-wrapper" style="display:none;">
                 {# Load default table content   #}
                 {{ block.super }}
             </div> {# End table-wrapper #}
-
-        </div> {# End column-shifter-container #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}
-
 {% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
@@ -2,7 +2,15 @@
 
 {% block table %}
     {% if table.shift_table_column %}
-        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+
+            {# Wrapper default is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap4.html
@@ -1,5 +1,9 @@
 {% extends "django_tables2/bootstrap4.html" %}
 
 {% block table %}
-    {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+    {% if table.shift_table_column %}
+        {% include 'django_tables2_column_shifter/_partials/bootstrap4_table_block.html' %}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
 {% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,0 +1,17 @@
+{% extends "django_tables2/bootstrap5-responsive.html" %}
+
+{% block table %}
+{% if table.shift_table_column %}
+    <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+
+        {# Wrapper default is hide #}
+        <div class="table-wrapper" style="display:none;">
+            {# Load default table content   #}
+            {{ block.super }}
+        </div> {# End table-wrapper #}
+     </div> {# End column-shifter-container #}
+{% else %}
+    {{ block.super }}
+{% endif %}
+{% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,4 +1,4 @@
-{% extends "django_tables2/bootstrap5-responsive.html" %}
+{% extends "django_tables2/bootstrap5.html" %}
 
 {% block table-wrapper %}
 <div class="table-container table-responsive">
@@ -17,6 +17,7 @@
         {{ block.super }}
     {% endif %}
     {% endblock table %}
+
     {% block pagination %}
         {{ block.super }}
     {% endblock pagination %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -2,7 +2,15 @@
 
 {% block table %}
     {% if table.shift_table_column %}
-        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+
+            {# Wrapper default is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,6 +1,8 @@
 {% extends "django_tables2/bootstrap5-responsive.html" %}
 
-{% block table %}
+{% block table-wrapper %}
+<div class="table-container table-responsive">
+    {% block table %}
     {% if table.shift_table_column %}
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
             {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
@@ -14,4 +16,9 @@
     {% else %}
         {{ block.super }}
     {% endif %}
-{% endblock table %}
+    {% endblock table %}
+    {% block pagination %}
+        {{ block.super }}
+    {% endblock pagination %}
+</div>
+{% endblock table-wrapper %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,7 +1,5 @@
-{% extends "django_tables2/bootstrap5.html" %}
+{% extends "django_tables2/bootstrap5-responsive.html" %}
 
-{% block table-wrapper %}
-<div class="table-container table-responsive">
     {% block table %}
     {% if table.shift_table_column %}
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
@@ -17,9 +15,3 @@
         {{ block.super }}
     {% endif %}
     {% endblock table %}
-
-    {% block pagination %}
-        {{ block.super }}
-    {% endblock pagination %}
-</div>
-{% endblock table-wrapper %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,5 +1,9 @@
 {% extends "django_tables2/bootstrap5-responsive.html" %}
 
 {% block table %}
-    {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+    {% if table.shift_table_column %}
+        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
 {% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,17 +1,17 @@
 {% extends "django_tables2/bootstrap5-responsive.html" %}
 
-    {% block table %}
-    {% if table.shift_table_column %}
-        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
-            {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+{% block table %}
+{% if table.shift_table_column %}
+    <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
 
-            {# Wrapper default is hide #}
-            <div class="table-wrapper" style="display:none;">
-                {# Load default table content   #}
-                {{ block.super }}
-            </div> {# End table-wrapper #}
-         </div> {# End column-shifter-container #}
-    {% else %}
-        {{ block.super }}
-    {% endif %}
-    {% endblock table %}
+        {# Wrapper default is hide #}
+        <div class="table-wrapper" style="display:none;">
+            {# Load default table content   #}
+            {{ block.super }}
+        </div> {# End table-wrapper #}
+     </div> {# End column-shifter-container #}
+{% else %}
+    {{ block.super }}
+{% endif %}
+{% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5-responsive.html
@@ -1,4 +1,4 @@
-{% extends "django_tables2/bootstrap5.html" %}
+{% extends "django_tables2/bootstrap5-responsive.html" %}
 
 {% block table %}
     {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
@@ -1,99 +1,17 @@
-{% extends "django_tables2/bootstrap4.html" %}
-{% load trans from i18n %}
-{% load static %}
+{% extends "django_tables2/bootstrap5.html" %}
 
 {% block table %}
-
     {% if table.shift_table_column %}
-
         <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
 
-            <div class="btn-group">
-                <button type="button" class="{{ table.get_dropdown_button_css }} dropdown-toggle"
-                        data-bs-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        id="btn_{{ table.uniq_table_class_name }}"
-                >
-                    <img
-                        src="{% static "django_tables2_column_shifter/img/cols.png" %}"
-                        alt="Columns"
-                        style="
-                            width:20px;
-                            height:16px;
-                            margin-right:5px;
-                            opacity:0.7;"
-                    />
-                    {% trans "Visible columns" %}
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu"
-                    style="min-width:350px; padding:5px; cursor:pointer;"
-                    aria-labelledby="btn_{{ table.uniq_table_class_name }}"
-                >
-                    {% for column in table.columns %}
-                        {% if column.attrs.td.class not in table.get_column_excluded %}
-                            {% if column.attrs.td.class in table.get_column_default_show %}
-                                <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
-                                    data-state="on"
-                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
-                                    data-table-class-container="{{ table.uniq_table_class_name }}">
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
-                                        class="ico check"
-                                    />
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; display: none; opacity:0.7;"
-                                        class="ico uncheck"
-                                    />
-                                    {{ column.header }}
-                                </li>
-                            {% else %}
-                                <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
-                                    data-state="off"
-                                    {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
-                                    data-table-class-container="{{ table.uniq_table_class_name }}">
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/check.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; display:none; opacity:0.7;"
-                                        class="ico check"
-                                    />
-                                    <img
-                                        src="{% static "django_tables2_column_shifter/img/uncheck.png" %}"
-                                        alt="loader"
-                                        style="width:20px; height:20px; margin-right:5px; opacity:0.7;"
-                                        class="ico uncheck"
-                                    />
-                                    {{ column.header }}
-                                </li>
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            </div> {# End  btn-group#}
-
-            {# Loader default is show #}
-            <div class="loader" style="text-align:center;" >
-                <img src="{% static "django_tables2_column_shifter/img/loader.gif" %}" style="margin:5px auto;" alt="loader"/>
-                {% trans "Table content is loading..."%}
-            </div> {# End loader #}
-
-            {# Wrapper degault is hide #}
+            {# Wrapper default is hide #}
             <div class="table-wrapper" style="display:none;">
                 {# Load default table content   #}
                 {{ block.super }}
             </div> {# End table-wrapper #}
-
-        </div> {# End column-shifter-container #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}
-
 {% endblock table %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
@@ -2,7 +2,15 @@
 
 {% block table %}
     {% if table.shift_table_column %}
-        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+        <div id="{{ table.uniq_table_class_name }}" class="column-shifter-container">
+            {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+
+            {# Wrapper default is hide #}
+            <div class="table-wrapper" style="display:none;">
+                {# Load default table content   #}
+                {{ block.super }}
+            </div> {# End table-wrapper #}
+         </div> {# End column-shifter-container #}
     {% else %}
         {{ block.super }}
     {% endif %}

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/bootstrap5.html
@@ -1,5 +1,9 @@
 {% extends "django_tables2/bootstrap5.html" %}
 
 {% block table %}
-    {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+    {% if table.shift_table_column %}
+        {% include 'django_tables2_column_shifter/_partials/bootstrap5_table_block.html' %}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
 {% endblock table %}

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -63,7 +63,7 @@ class DjangoTables2ColumnShifterTest(TestCase):
         },
         {
             'bootstrap_version': 'bootstrap5responsive',
-            'min_dt_version': (2, 0),
+            'min_dt_version': (2, 5, 3),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5-responsive.html',
             'table_clsss': ColumnShiftTableBootstrap5Responsive,

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -49,7 +49,7 @@ class DjangoTables2ColumnShifterTest(TestCase):
         },
         {
             'bootstrap_version': 'bootstrap4responsive',
-            'min_dt_version': (2, 0),
+            'min_dt_version': (2, 5),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap4-responsive.html',
             'table_clsss': ColumnShiftTableBootstrap4Responsive,

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -12,7 +12,9 @@ from django_tables2_column_shifter.tables import (
     ColumnShiftTableBootstrap2,
     ColumnShiftTableBootstrap3,
     ColumnShiftTableBootstrap4,
+    ColumnShiftTableBootstrap4Responsive,
     ColumnShiftTableBootstrap5,
+    ColumnShiftTableBootstrap5Responsive
 )
 
 if tuple(map(int, django.__version__.split(".")[:2])) >= (1, 10):
@@ -46,11 +48,25 @@ class DjangoTables2ColumnShifterTest(TestCase):
             'table_clsss': ColumnShiftTableBootstrap4,
         },
         {
+            'bootstrap_version': 'bootstrap4responsive',
+            'min_dt_version': (2, 0),
+            'max_dt_version': None,
+            'template_name': 'django_tables2_column_shifter/bootstrap4-responsive.html',
+            'table_clsss': ColumnShiftTableBootstrap4Responsive,
+        },
+        {
             'bootstrap_version': 'bootstrap5',
             'min_dt_version': (2, 0),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5.html',
             'table_clsss': ColumnShiftTableBootstrap5,
+        },
+        {
+            'bootstrap_version': 'bootstrap5responsive',
+            'min_dt_version': (2, 0),
+            'max_dt_version': None,
+            'template_name': 'django_tables2_column_shifter/bootstrap5-responsive.html',
+            'table_clsss': ColumnShiftTableBootstrap5Responsive,
         },
     ]
 

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -9,6 +9,7 @@ from django.template import Template, Context
 
 from django_tables2_column_shifter.tests.models import Author
 from django_tables2_column_shifter.tables import (
+    dt_version,
     ColumnShiftTableBootstrap2,
     ColumnShiftTableBootstrap3,
     ColumnShiftTableBootstrap4,
@@ -16,7 +17,6 @@ from django_tables2_column_shifter.tables import (
     ColumnShiftTableBootstrap5,
     ColumnShiftTableBootstrap5Responsive
 )
-from django_tables2_column_shifter.tables import dt_version
 
 if tuple(map(int, django.__version__.split(".")[:2])) >= (1, 10):
     from django.urls import reverse

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -48,11 +48,25 @@ class DjangoTables2ColumnShifterTest(TestCase):
             'table_clsss': ColumnShiftTableBootstrap4,
         },
         {
+            'bootstrap_version': 'bootstrap4responsive',
+            'min_dt_version': (2, 5),
+            'max_dt_version': None,
+            'template_name': 'django_tables2_column_shifter/bootstrap4-responsive.html',
+            'table_clsss': ColumnShiftTableBootstrap4Responsive,
+        },
+        {
             'bootstrap_version': 'bootstrap5',
-            'min_dt_version': (2, 0),
+            'min_dt_version': (2, 5),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5.html',
             'table_clsss': ColumnShiftTableBootstrap5,
+        },
+        {
+            'bootstrap_version': 'bootstrap5responsive',
+            'min_dt_version': (2, 5),
+            'max_dt_version': None,
+            'template_name': 'django_tables2_column_shifter/bootstrap5-responsive.html',
+            'table_clsss': ColumnShiftTableBootstrap5Responsive,
         },
     ]
 

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -56,7 +56,7 @@ class DjangoTables2ColumnShifterTest(TestCase):
         },
         {
             'bootstrap_version': 'bootstrap5',
-            'min_dt_version': (2, 0),
+            'min_dt_version': (2, 5),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5.html',
             'table_clsss': ColumnShiftTableBootstrap5,

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -16,6 +16,7 @@ from django_tables2_column_shifter.tables import (
     ColumnShiftTableBootstrap5,
     ColumnShiftTableBootstrap5Responsive
 )
+from django_tables2_column_shifter.tables import dt_version
 
 if tuple(map(int, django.__version__.split(".")[:2])) >= (1, 10):
     from django.urls import reverse
@@ -24,53 +25,50 @@ else:
 
 
 class DjangoTables2ColumnShifterTest(TestCase):
-
     CASE = [
         {
             'bootstrap_version': 'bootstrap2',
-            'min_dt_version': (1, 0),
-            'max_dt_version': (2, 0),
+            'min_dt_version': (1, 0, 0),
+            'max_dt_version': (2, 0, 0),
             'template_name': 'django_tables2_column_shifter/bootstrap2.html',
             'table_clsss': ColumnShiftTableBootstrap2,
         },
         {
             'bootstrap_version': 'bootstrap3',
-            'min_dt_version': (1, 0),
-            'max_dt_version': (2, 0),
+            'min_dt_version': (1, 0, 0),
+            'max_dt_version': (2, 0, 0),
             'template_name': 'django_tables2_column_shifter/bootstrap3.html',
             'table_clsss': ColumnShiftTableBootstrap3,
         },
         {
             'bootstrap_version': 'bootstrap4',
-            'min_dt_version': (2, 0),
+            'min_dt_version': (2, 0, 0),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap4.html',
             'table_clsss': ColumnShiftTableBootstrap4,
         },
         {
             'bootstrap_version': 'bootstrap4responsive',
-            'min_dt_version': (2, 5),
+            'min_dt_version': (2, 5, 0),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap4-responsive.html',
             'table_clsss': ColumnShiftTableBootstrap4Responsive,
         },
         {
             'bootstrap_version': 'bootstrap5',
-            'min_dt_version': (2, 5),
+            'min_dt_version': (2, 5, 0),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5.html',
             'table_clsss': ColumnShiftTableBootstrap5,
         },
         {
             'bootstrap_version': 'bootstrap5responsive',
-            'min_dt_version': (2, 5),
+            'min_dt_version': (2, 5, 3),
             'max_dt_version': None,
             'template_name': 'django_tables2_column_shifter/bootstrap5-responsive.html',
             'table_clsss': ColumnShiftTableBootstrap5Responsive,
         },
     ]
-
-    dt_version = tuple(map(int, tables.__version__.split(".")[:2]))
 
     def setUp(self):
         # Add authors to database
@@ -85,8 +83,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_CASE_status(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -95,8 +93,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_general_html_content(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -108,8 +106,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_container_ids(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -120,8 +118,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_tables_containers_count(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -130,8 +128,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_buttons_count(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -140,8 +138,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_btn_on_status_count(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -150,8 +148,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_btn_off_status_count(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -160,8 +158,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_is_pagination(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
             response = self.client.get(reverse(case['bootstrap_version']))
@@ -171,8 +169,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
     def test_tables_template(self):
         for case in self.CASE:
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
 
@@ -217,8 +215,8 @@ class DjangoTables2ColumnShifterTest(TestCase):
         for case in self.CASE:
 
             if (
-                (case['min_dt_version'] and case['min_dt_version'] > self.dt_version) or
-                (case['max_dt_version'] and case['max_dt_version'] < self.dt_version)
+                    (case['min_dt_version'] and case['min_dt_version'] > dt_version) or
+                    (case['max_dt_version'] and case['max_dt_version'] < dt_version)
             ):
                 continue
 

--- a/django_tables2_column_shifter/tests/urls.py
+++ b/django_tables2_column_shifter/tests/urls.py
@@ -1,6 +1,13 @@
 import django
 
-from .views import Bootstrap2, Bootstrap3, Bootstrap4, Bootstrap4Responsive, Bootstrap5, Bootstrap5Responsive
+from .views import (
+    Bootstrap2,
+    Bootstrap3,
+    Bootstrap4,
+    Bootstrap4Responsive,
+    Bootstrap5,
+    Bootstrap5Responsive,
+)
 
 dj_version = tuple(map(int, django.__version__.split(".")[:2]))
 
@@ -14,12 +21,12 @@ urlpatterns = [
     url(r'^bootstrap2/$', Bootstrap2.as_view(), name="bootstrap2"),
     url(r'^bootstrap3/$', Bootstrap3.as_view(), name="bootstrap3"),
     url(r'^bootstrap4/$', Bootstrap4.as_view(), name="bootstrap4"),
+    url(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
     url(
         r'^bootstrap4responsive/$',
         Bootstrap4Responsive.as_view(),
         name="bootstrap4responsive",
     ),
-    url(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
     url(
         r'^bootstrap5responsive/$',
         Bootstrap5Responsive.as_view(),

--- a/django_tables2_column_shifter/tests/urls.py
+++ b/django_tables2_column_shifter/tests/urls.py
@@ -1,6 +1,6 @@
 import django
 
-from .views import Bootstrap2, Bootstrap3, Bootstrap4, Bootstrap5
+from .views import Bootstrap2, Bootstrap3, Bootstrap4, Bootstrap4Responsive, Bootstrap5, Bootstrap5Responsive
 
 dj_version = tuple(map(int, django.__version__.split(".")[:2]))
 
@@ -14,5 +14,7 @@ urlpatterns = [
     url(r'^bootstrap2/$', Bootstrap2.as_view(), name="bootstrap2"),
     url(r'^bootstrap3/$', Bootstrap3.as_view(), name="bootstrap3"),
     url(r'^bootstrap4/$', Bootstrap4.as_view(), name="bootstrap4"),
+    url(r'^bootstrap4responsive/$', Bootstrap4Responsive.as_view(), name="bootstrap4responsive"),
     url(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
+    url(r'^bootstrap5responsive/$', Bootstrap5Responsive.as_view(), name="bootstrap5responsive"),
 ]

--- a/django_tables2_column_shifter/tests/urls.py
+++ b/django_tables2_column_shifter/tests/urls.py
@@ -14,7 +14,15 @@ urlpatterns = [
     url(r'^bootstrap2/$', Bootstrap2.as_view(), name="bootstrap2"),
     url(r'^bootstrap3/$', Bootstrap3.as_view(), name="bootstrap3"),
     url(r'^bootstrap4/$', Bootstrap4.as_view(), name="bootstrap4"),
-    url(r'^bootstrap4responsive/$', Bootstrap4Responsive.as_view(), name="bootstrap4responsive"),
+    url(
+        r'^bootstrap4responsive/$',
+        Bootstrap4Responsive.as_view(),
+        name="bootstrap4responsive",
+    ),
     url(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
-    url(r'^bootstrap5responsive/$', Bootstrap5Responsive.as_view(), name="bootstrap5responsive"),
+    url(
+        r'^bootstrap5responsive/$',
+        Bootstrap5Responsive.as_view(),
+        name="bootstrap5responsive",
+    ),
 ]

--- a/django_tables2_column_shifter/tests/views.py
+++ b/django_tables2_column_shifter/tests/views.py
@@ -58,8 +58,12 @@ class Bootstrap4(BootstrapDefault):
 
 
 class Bootstrap4Responsive(BootstrapDefault):
-    author_table_class = get_author_table_class(ColumnShiftTableBootstrap4Responsive)
-    book_table_class = get_book_table_class(ColumnShiftTableBootstrap4Responsive)
+    author_table_class = get_author_table_class(
+        ColumnShiftTableBootstrap4Responsive,
+    )
+    book_table_class = get_book_table_class(
+        ColumnShiftTableBootstrap4Responsive,
+    )
 
 
 class Bootstrap5(BootstrapDefault):
@@ -68,5 +72,9 @@ class Bootstrap5(BootstrapDefault):
 
 
 class Bootstrap5Responsive(BootstrapDefault):
-    author_table_class = get_author_table_class(ColumnShiftTableBootstrap5Responsive)
-    book_table_class = get_book_table_class(ColumnShiftTableBootstrap5Responsive)
+    author_table_class = get_author_table_class(
+        ColumnShiftTableBootstrap5Responsive,
+    )
+    book_table_class = get_book_table_class(
+        ColumnShiftTableBootstrap5Responsive
+    )

--- a/django_tables2_column_shifter/tests/views.py
+++ b/django_tables2_column_shifter/tests/views.py
@@ -5,7 +5,9 @@ from django_tables2_column_shifter.tables import (
     ColumnShiftTableBootstrap2,
     ColumnShiftTableBootstrap3,
     ColumnShiftTableBootstrap4,
+    ColumnShiftTableBootstrap4Responsive,
     ColumnShiftTableBootstrap5,
+    ColumnShiftTableBootstrap5Responsive,
 )
 
 from .models import Author, Book
@@ -15,7 +17,7 @@ from .tables import get_author_table_class, get_book_table_class
 class BootstrapDefault(TemplateView):
     template_name = "django_tables2_column_shifter_tests/index.html"
     author_table_class = None  # should be override
-    book_table_class = None    # should be override
+    book_table_class = None  # should be override
 
     def get_context_data(self, **kwargs):
         context = super(BootstrapDefault, self).get_context_data(**kwargs)
@@ -55,6 +57,16 @@ class Bootstrap4(BootstrapDefault):
     book_table_class = get_book_table_class(ColumnShiftTableBootstrap4)
 
 
+class Bootstrap4Responsive(BootstrapDefault):
+    author_table_class = get_author_table_class(ColumnShiftTableBootstrap4Responsive)
+    book_table_class = get_book_table_class(ColumnShiftTableBootstrap4Responsive)
+
+
 class Bootstrap5(BootstrapDefault):
     author_table_class = get_author_table_class(ColumnShiftTableBootstrap5)
     book_table_class = get_book_table_class(ColumnShiftTableBootstrap5)
+
+
+class Bootstrap5Responsive(BootstrapDefault):
+    author_table_class = get_author_table_class(ColumnShiftTableBootstrap5Responsive)
+    book_table_class = get_book_table_class(ColumnShiftTableBootstrap5Responsive)

--- a/testproject/testproject/templates/base_site.html
+++ b/testproject/testproject/templates/base_site.html
@@ -10,14 +10,32 @@
                         <div class="row" style="margin-top:10px;">
                             <div class="col-md-12 text-center well">
                                 <h2 style="margin:20px;">Choose bootstrap version</h2>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap2" %}"> Bootstrap 2 </a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap3" %}"> Bootstrap 3 </a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap4" %}"> Bootstrap 4 </a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap4responsive" %}"> Bootstrap 4  (responsive)</a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap4_1_3" %}"> Bootstrap 4.1.3 </a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap5" %}"> Bootstrap 5 beta3</a>
-                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap5responsive" %}"> Bootstrap 5 beta3 (responsive)</a>
+                                <p>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap2" %}"> Bootstrap 2 </a>
+                                </p>
+                                <p>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap3" %}"> Bootstrap 3 </a>
+                                </p>
+                                <p>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap4" %}">
+                                        &ensp;Bootstrap 4&ensp;
+                                    </a>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap4responsive" %}">
+                                        &ensp;Bootstrap 4 (responsive)&ensp;
+                                    </a>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap4_1_3" %}">
+                                        &ensp;Bootstrap4.1.3&ensp;
+                                    </a>
+                                </p>
+                                <p>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap5" %}">
+                                        &ensp;Bootstrap 5 beta3&ensp;
+                                    </a>
+                                    <a class="btn btn-lg btn-primary" href="{% url "bootstrap5responsive" %}">
+                                        &ensp;Bootstrap 5 beta3 (responsive)&ensp;
+                                    </a>
                             </div>
+                        </div>
                         </div>
                     {% endblock %}
                 </div>
@@ -28,6 +46,5 @@
                 </div>
 
             {% endblock container %}
-        </div>
     </div>
 {% endblock body %}

--- a/testproject/testproject/templates/base_site.html
+++ b/testproject/testproject/templates/base_site.html
@@ -13,8 +13,10 @@
                                 <a class="btn btn-lg btn-primary" href="{% url "bootstrap2" %}"> Bootstrap 2 </a>
                                 <a class="btn btn-lg btn-primary" href="{% url "bootstrap3" %}"> Bootstrap 3 </a>
                                 <a class="btn btn-lg btn-primary" href="{% url "bootstrap4" %}"> Bootstrap 4 </a>
+                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap4responsive" %}"> Bootstrap 4  (responsive)</a>
                                 <a class="btn btn-lg btn-primary" href="{% url "bootstrap4_1_3" %}"> Bootstrap 4.1.3 </a>
                                 <a class="btn btn-lg btn-primary" href="{% url "bootstrap5" %}"> Bootstrap 5 beta3</a>
+                                <a class="btn btn-lg btn-primary" href="{% url "bootstrap5responsive" %}"> Bootstrap 5 beta3 (responsive)</a>
                             </div>
                         </div>
                     {% endblock %}

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -18,8 +18,16 @@ urlpatterns = [
     re_path(r'^bootstrap2/$', Bootstrap2.as_view(), name="bootstrap2"),
     re_path(r'^bootstrap3/$', Bootstrap3.as_view(), name="bootstrap3"),
     re_path(r'^bootstrap4/$', Bootstrap4.as_view(), name="bootstrap4"),
-    re_path(r'^bootstrap4-responsive/$', Bootstrap4Responsive.as_view(), name="bootstrap4responsive"),
+    re_path(
+        r'^bootstrap4-responsive/$',
+        Bootstrap4Responsive.as_view(),
+        name="bootstrap4responsive",
+    ),
     re_path(r'^bootstrap4_1_3/$', Bootstrap4_1_3.as_view(), name="bootstrap4_1_3"),
     re_path(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
-    re_path(r'^bootstrap5-responsive/$', Bootstrap5Responsive.as_view(), name="bootstrap5responsive"),
+    re_path(
+        r'^bootstrap5-responsive/$',
+        Bootstrap5Responsive.as_view(),
+        name="bootstrap5responsive",
+    ),
 ]

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -6,8 +6,10 @@ from .views import (
     Bootstrap2,
     Bootstrap3,
     Bootstrap4,
+    Bootstrap4Responsive,
     Bootstrap4_1_3,
     Bootstrap5,
+    Bootstrap5Responsive,
     Index,
 )
 
@@ -16,6 +18,8 @@ urlpatterns = [
     re_path(r'^bootstrap2/$', Bootstrap2.as_view(), name="bootstrap2"),
     re_path(r'^bootstrap3/$', Bootstrap3.as_view(), name="bootstrap3"),
     re_path(r'^bootstrap4/$', Bootstrap4.as_view(), name="bootstrap4"),
+    re_path(r'^bootstrap4-responsive/$', Bootstrap4Responsive.as_view(), name="bootstrap4responsive"),
     re_path(r'^bootstrap4_1_3/$', Bootstrap4_1_3.as_view(), name="bootstrap4_1_3"),
     re_path(r'^bootstrap5/$', Bootstrap5.as_view(), name="bootstrap5"),
+    re_path(r'^bootstrap5-responsive/$', Bootstrap5Responsive.as_view(), name="bootstrap5responsive"),
 ]

--- a/testproject/testproject/views.py
+++ b/testproject/testproject/views.py
@@ -5,7 +5,9 @@ from django_tables2_column_shifter.tables import (
     ColumnShiftTableBootstrap2,
     ColumnShiftTableBootstrap3,
     ColumnShiftTableBootstrap4,
+    ColumnShiftTableBootstrap4Responsive,
     ColumnShiftTableBootstrap5,
+    ColumnShiftTableBootstrap5Responsive,
 )
 
 from .models import Author, Book
@@ -17,7 +19,6 @@ class Index(TemplateView):
 
 
 class Base(object):
-
     container_css = "span10 offset1"
     template_name = "testproject/test_bootstrap2.html"
     table_class_version = ColumnShiftTableBootstrap2
@@ -68,6 +69,12 @@ class Bootstrap4(Base, TemplateView):
     table_class_version = ColumnShiftTableBootstrap4
 
 
+class Bootstrap4Responsive(Base, TemplateView):
+    container_css = "col-xs-10 col-xs-offset-1"
+    template_name = "testproject/test_bootstrap4.html"
+    table_class_version = ColumnShiftTableBootstrap4Responsive
+
+
 class Bootstrap4_1_3(Base, TemplateView):
     container_css = "col-xs-10 col-xs-offset-1"
     template_name = "testproject/test_bootstrap4.1.3.html"
@@ -78,3 +85,9 @@ class Bootstrap5(Base, TemplateView):
     container_css = "col-xs-10 col-xs-offset-1"
     template_name = "testproject/test_bootstrap5.html"
     table_class_version = ColumnShiftTableBootstrap5
+
+
+class Bootstrap5Responsive(Base, TemplateView):
+    container_css = "col-xs-10 col-xs-offset-1"
+    template_name = "testproject/test_bootstrap5.html"
+    table_class_version = ColumnShiftTableBootstrap5Responsive


### PR DESCRIPTION
I wrote a proof of concept for implementing responsive tables for Bootstrap v4 and v5. Basically the goal was to use another base template from `django-tables2`. To make it DRY I needed to introduce some partials and move some of the code out of the templates for re-use. 

Roughly tested it in my projects and it completely does fulfill my needs.