### PR TITLE
Fix issue when different class is defined in attrs for th and td

### DIFF
--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap4_table_block.html
@@ -28,7 +28,7 @@
                         {% if column.attrs.td.class not in table.get_column_excluded %}
                             {% if column.attrs.td.class in table.get_column_default_show %}
                                 <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-td-class="{{ column.name }}"
                                     data-state="on"
                                     {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
                                     data-table-class-container="{{ table.uniq_table_class_name }}">
@@ -48,7 +48,7 @@
                                 </li>
                             {% else %}
                                 <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-td-class="{{ column.name }}"
                                     data-state="off"
                                     {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
                                     data-table-class-container="{{ table.uniq_table_class_name }}">

--- a/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
+++ b/django_tables2_column_shifter/templates/django_tables2_column_shifter/_partials/bootstrap5_table_block.html
@@ -28,7 +28,7 @@
                         {% if column.attrs.td.class not in table.get_column_excluded %}
                             {% if column.attrs.td.class in table.get_column_default_show %}
                                 <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-td-class="{{ column.name }}"
                                     data-state="on"
                                     {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
                                     data-table-class-container="{{ table.uniq_table_class_name }}">
@@ -48,7 +48,7 @@
                                 </li>
                             {% else %}
                                 <li class="btn-shift-column"
-                                    data-td-class="{{ column.attrs.td.class }}"
+                                    data-td-class="{{ column.name }}"
                                     data-state="off"
                                     {% if not forloop.last %} style="border-bottom:1px solid #ccc;" {%endif %}
                                     data-table-class-container="{{ table.uniq_table_class_name }}">

--- a/django_tables2_column_shifter/tests/test_base.py
+++ b/django_tables2_column_shifter/tests/test_base.py
@@ -239,3 +239,41 @@ class DjangoTables2ColumnShifterTest(TestCase):
             self.assertTrue('data-td-class="age"' in render)
             self.assertFalse('data-td-class="first_name"' in render)
             self.assertFalse('data-td-class="last_name"' in render)
+
+    def test_class_attrs(self):
+        """
+        Class for targeting should be col name even if class defined in attrs
+        """
+
+        for case in self.CASE:
+
+            if (
+                case["min_dt_version"] and case["min_dt_version"] > dt_version
+            ) or (
+                case["max_dt_version"] and case["max_dt_version"] < dt_version
+            ):
+                continue
+
+            class Tab(case["table_clsss"]):
+                first_name = tables.Column(
+                    attrs={
+                        "th": {"class": "text-nowrap"},
+                        "td": {"class": "text-center"},
+                    }
+                )
+
+                class Meta:
+                    model = Author
+
+            table = Tab(Author.objects.all())
+            request = RequestFactory().get("/fake/url")
+            template = Template(
+                """
+                {% load django_tables2 %}
+                {% render_table table %}
+            """
+            )
+            ctx = Context({"table": table, "request": request})
+            render = template.render(ctx)
+
+            self.assertTrue('data-td-class="first_name"' in render)


### PR DESCRIPTION
When `class` is defined differently for `th` and `td` in the `attrs` attribute, for example,

```python
class TestTable(ColumnShiftTableBootstrap5):
    test_col = tables.Column(
        attrs={"th": {"class": "text-nowrap"}, "td": {"class": "text-center"}}
    )
```

column hiding doesn't work because the value for `data-td-class` becomes wrong. This PR fixes this by setting it to the column name itself which is always a `class` of `th` and `td`.